### PR TITLE
Update version to 1.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.diffblue.cover</groupId>
   <artifactId>cover-annotations</artifactId>
-  <version>1.2.0</version>
+  <version>1.3.0</version>
   <packaging>jar</packaging>
 
   <name>Cover Annotations</name>

--- a/src/main/java/com/diffblue/cover/annotations/MaintainedByDiffblue.java
+++ b/src/main/java/com/diffblue/cover/annotations/MaintainedByDiffblue.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Diffblue Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.diffblue.cover.annotations;
+
+/**
+ * Empty interface, required, with the Category annotation, to label JUnit 4 tests in the following
+ * manner: @Category(MaintainedByDiffblue.class)
+ */
+public interface MaintainedByDiffblue {}


### PR DESCRIPTION
Adds the `MaintainedByDiffblue` interface. This is an empty interface that is require when using the `@Category` annotation for marking JUnit 4 tests.