### PR TITLE
Release 1.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.diffblue.cover</groupId>
   <artifactId>cover-annotations</artifactId>
-  <version>1.2.0</version>
+  <version>1.3.0</version>
   <packaging>jar</packaging>
 
   <name>Cover Annotations</name>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.diffblue.cover</groupId>
   <artifactId>cover-annotations</artifactId>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <packaging>jar</packaging>
 
   <name>Cover Annotations</name>

--- a/src/main/java/com/diffblue/cover/annotations/MaintainedByDiffblue.java
+++ b/src/main/java/com/diffblue/cover/annotations/MaintainedByDiffblue.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Diffblue Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.diffblue.cover.annotations;
+
+/**
+ * Empty interface, required, with the Category annotation, to label JUnit 4 tests in the following
+ * manner: @Category(MaintainedByDiffblue.class)
+ */
+public interface MaintainedByDiffblue {}

--- a/src/main/java/com/diffblue/cover/annotations/MethodsUnderTest.java
+++ b/src/main/java/com/diffblue/cover/annotations/MethodsUnderTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Diffblue Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.diffblue.cover.annotations;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates the methods being tested in the annotated test method. Diffblue Cover attaches this
+ * annotation to all tests that it creates.
+ */
+@Retention(SOURCE)
+@Target(METHOD)
+public @interface MethodsUnderTest {
+
+  String[] value();
+}


### PR DESCRIPTION
Release 1.3.0 of cover-annotations.

Added `MaintainedByDiffblue` interface - a blank interface required for the use of `@Category` annotation with JUnit 4 test