### PR TITLE
TG-23050 Specifying returnValueFactory for  @InTestsMock

### DIFF
--- a/src/main/java/com/diffblue/cover/annotations/InTestsMock.java
+++ b/src/main/java/com/diffblue/cover/annotations/InTestsMock.java
@@ -81,4 +81,10 @@ public @interface InTestsMock {
 
   /** @return String value or values to return from the {@link #method()} */
   String[] stringReturnValues() default {};
+
+  /**
+   * @return name of the factory method used to create the object returned by the mocked {@link
+   *     #method()}
+   */
+  String returnValueFactory() default "";
 }


### PR DESCRIPTION
## JIRA Link (if applicable)

TG-23050

## Description

Specifies the returnValueFactory for creating a mocked object.
The returnValueFactory contains the name of the factory method used to create the object returned by the mocked method specified in the method field.
See also PR for cover: https://github.com/diffblue/cover/pull/13354
