### PR TITLE
TG-23051  throwException and throwExceptionFactory for @InTestsMock

### DIFF
--- a/src/main/java/com/diffblue/cover/annotations/InTestsMock.java
+++ b/src/main/java/com/diffblue/cover/annotations/InTestsMock.java
@@ -20,6 +20,7 @@ import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import com.diffblue.cover.annotations.exceptions.NoException;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -87,4 +88,16 @@ public @interface InTestsMock {
    *     #method()}
    */
   String returnValueFactory() default "";
+
+  /**
+   * @return exception type to throw when the mocked {@link #method()} is called. Defaults to {@link
+   *     NoException} to indicate no exception should be thrown.
+   */
+  Class<? extends Throwable> throwException() default NoException.class;
+
+  /**
+   * @return fully qualified name of the factory method used to create the exception to throw when
+   *     the mocked {@link #method()} is called.
+   */
+  String throwExceptionFactory() default "";
 }

--- a/src/main/java/com/diffblue/cover/annotations/exceptions/NoException.java
+++ b/src/main/java/com/diffblue/cover/annotations/exceptions/NoException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 Diffblue Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.diffblue.cover.annotations.exceptions;
+
+/**
+ * Marker class used to indicate that no exception should be thrown by default in {@link
+ * com.diffblue.cover.annotations.InTestsMock#throwException()}.
+ */
+public final class NoException extends Throwable {
+  private NoException() {
+    // This class should not be instantiated.
+  }
+}


### PR DESCRIPTION
TG-23051
Changed annotations
- `@InTestsMock` - new attributes `throwException` and `throwExceptionFactory`
Supported by Diffblue Cover from 2025.06.02
See https://docs.diffblue.com/features/cover-annotations/mocking-annotations for more details
**Full Changelog**: https://github.com/diffblue/cover-annotations/compare/[v1.5.0]...[v1.6.0]