### PR TITLE
Update version to 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ For installation into a Gradle project the `compileOnly` and `testImplementation
 
 ```
 dependencies {
-    compileOnly("com.diffblue.cover:cover-annotations:1.5.0")
+    compileOnly("com.diffblue.cover:cover-annotations:1.6.0")
 
-    testImplementation("com.diffblue.cover:cover-annotations:1.5.0")    
+    testImplementation("com.diffblue.cover:cover-annotations:1.6.0")    
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.diffblue.cover</groupId>
   <artifactId>cover-annotations</artifactId>
-  <version>1.5.0</version>
+  <version>1.6.0</version>
   <packaging>jar</packaging>
 
   <name>Cover Annotations</name>


### PR DESCRIPTION
TG-23051
Changed annotations
- `@InTestsMock` - new attributes `throwException` and `throwExceptionFactory`
Supported by Diffblue Cover from 2025.06.02
See https://docs.diffblue.com/features/cover-annotations/mocking-annotations for more details
**Full Changelog**: https://github.com/diffblue/cover-annotations/compare/[v1.5.0]...[v1.6.0]