### PR TITLE
Release 1.6.0.

### DIFF
--- a/.github/settings.xml
+++ b/.github/settings.xml
@@ -8,9 +8,9 @@
             <passphrase>${env.GPG_PASSPHRASE}</passphrase>
         </server>
         <server>
-        <id>ossrh</id>
-        <username>${env.MAVEN_USERNAME}</username>
-        <password>${env.MAVEN_PASSWORD}</password>
+            <id>central</id>
+            <username>${env.MAVEN_USERNAME}</username>
+            <password>${env.MAVEN_PASSWORD}</password>
         </server>
     </servers>
     <profiles>

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ For installation into a Gradle project the `compileOnly` and `testImplementation
 
 ```
 dependencies {
-    compileOnly("com.diffblue.cover:cover-annotations:1.5.0")
+    compileOnly("com.diffblue.cover:cover-annotations:1.6.0")
 
-    testImplementation("com.diffblue.cover:cover-annotations:1.5.0")    
+    testImplementation("com.diffblue.cover:cover-annotations:1.6.0")    
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For installation into a Maven project the `provided` scope is recommended so tha
     <dependency>
         <groupId>com.diffblue.cover</groupId>
         <artifactId>cover-annotations</artifactId>
-        <version>1.4.0</version>
+        <version>1.5.0</version>
         <scope>provided</scope>
     </dependency>
 </dependencies>
@@ -36,9 +36,9 @@ For installation into a Gradle project the `compileOnly` and `testImplementation
 
 ```
 dependencies {
-    compileOnly("com.diffblue.cover:cover-annotations:1.4.0")
+    compileOnly("com.diffblue.cover:cover-annotations:1.5.0")
 
-    testImplementation("com.diffblue.cover:cover-annotations:1.4.0")    
+    testImplementation("com.diffblue.cover:cover-annotations:1.5.0")    
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,14 +71,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.13</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
         <extensions>true</extensions>
         <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>true</autoPublish>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.diffblue.cover</groupId>
   <artifactId>cover-annotations</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0</version>
   <packaging>jar</packaging>
 
   <name>Cover Annotations</name>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.diffblue.cover</groupId>
   <artifactId>cover-annotations</artifactId>
-  <version>1.5.0</version>
+  <version>1.6.0</version>
   <packaging>jar</packaging>
 
   <name>Cover Annotations</name>

--- a/src/main/java/com/diffblue/cover/annotations/InTestsMock.java
+++ b/src/main/java/com/diffblue/cover/annotations/InTestsMock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Diffblue Limited.
+ * Copyright 2024-2025 Diffblue Limited.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import static com.diffblue.cover.annotations.MockDecision.RECOMMENDED;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
@@ -32,29 +32,53 @@ import java.lang.annotation.Target;
  *
  * @since Diffblue Cover 2024.04.02
  */
-@Retention(CLASS)
+@Retention(RUNTIME)
 @Target({PACKAGE, TYPE, METHOD})
 @Repeatable(InTestsMock.Repeatable.class)
 public @interface InTestsMock {
 
   /** Collects multiple {@link InTestsMock} annotations. */
-  @Retention(CLASS)
+  @Retention(RUNTIME)
   @Target({PACKAGE, TYPE, METHOD})
   @interface Repeatable {
 
-    /**
-     * @return the repeated {@link InTestsMock} annotations.
-     */
+    /** @return the repeated {@link InTestsMock} annotations. */
     InTestsMock[] value();
   }
 
-  /**
-   * @return the classes to mock (or not).
-   */
+  /** @return the classes to mock (or not). */
   Class<?>[] value();
 
-  /**
-   * @return the mocking decision to apply.
-   */
+  /** @return the mocking decision to apply. */
   MockDecision decision() default RECOMMENDED;
+
+  /** @return name of method to mock */
+  String method() default "";
+
+  /** @return boolean value or values to return from the {@link #method()} */
+  boolean[] booleanReturnValues() default {};
+
+  /** @return byte value or values to return from the {@link #method()} */
+  byte[] byteReturnValues() default {};
+
+  /** @return char value or values to return from the {@link #method()} */
+  char[] charReturnValues() default {};
+
+  /** @return float value or values to return from the {@link #method()} */
+  float[] floatReturnValues() default {};
+
+  /** @return double value or values to return from the {@link #method()} */
+  double[] doubleReturnValues() default {};
+
+  /** @return int value or values to return from the {@link #method()} */
+  int[] intReturnValues() default {};
+
+  /** @return long value or values to return from the {@link #method()} */
+  long[] longReturnValues() default {};
+
+  /** @return short value or values to return from the {@link #method()} */
+  short[] shortReturnValues() default {};
+
+  /** @return String value or values to return from the {@link #method()} */
+  String[] stringReturnValues() default {};
 }

--- a/src/main/java/com/diffblue/cover/annotations/InTestsMock.java
+++ b/src/main/java/com/diffblue/cover/annotations/InTestsMock.java
@@ -81,4 +81,10 @@ public @interface InTestsMock {
 
   /** @return String value or values to return from the {@link #method()} */
   String[] stringReturnValues() default {};
+
+  /**
+   * @return name of the factory method used to create the object returned by the mocked {@link
+   *     #method()}
+   */
+  String returnValueFactory() default "";
 }

--- a/src/main/java/com/diffblue/cover/annotations/InTestsMock.java
+++ b/src/main/java/com/diffblue/cover/annotations/InTestsMock.java
@@ -20,6 +20,7 @@ import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import com.diffblue.cover.annotations.exceptions.NoException;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -87,4 +88,16 @@ public @interface InTestsMock {
    *     #method()}
    */
   String returnValueFactory() default "";
+
+  /**
+   * @return exception type to throw when the mocked {@link #method()} is called. Defaults to {@link
+   *     NoException} to indicate no exception should be thrown.
+   */
+  Class<? extends Throwable> throwException() default NoException.class;
+
+  /**
+   * @return fully qualified name of the factory method used to create the exception to throw when
+   *     the mocked {@link #method()} is called.
+   */
+  String throwExceptionFactory() default "";
 }

--- a/src/main/java/com/diffblue/cover/annotations/ManagedByDiffblue.java
+++ b/src/main/java/com/diffblue/cover/annotations/ManagedByDiffblue.java
@@ -14,8 +14,16 @@
  */
 package com.diffblue.cover.annotations;
 
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
 /**
- * Empty interface, identifies a test as managed by Diffblue. Tests annotated with this can be
- * removed or updated by Diffblue and so should not be adjusted manually.
+ * Annotation to identify a test as managed by Diffblue. Tests annotated with this can be removed or
+ * updated by Diffblue and so should not be adjusted manually.
  */
-public interface ManagedByDiffblue {}
+@Retention(SOURCE)
+@Target(METHOD)
+public @interface ManagedByDiffblue {}

--- a/src/main/java/com/diffblue/cover/annotations/exceptions/NoException.java
+++ b/src/main/java/com/diffblue/cover/annotations/exceptions/NoException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 Diffblue Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.diffblue.cover.annotations.exceptions;
+
+/**
+ * Marker class used to indicate that no exception should be thrown by default in {@link
+ * com.diffblue.cover.annotations.InTestsMock#throwException()}.
+ */
+public final class NoException extends Throwable {
+  private NoException() {
+    // This class should not be instantiated.
+  }
+}


### PR DESCRIPTION
TG-23050 Specifying returnValueFactory for @InTestsMock https://github.com/diffblue/cover-annotations/pull/33 
TG-23051 throwException and throwExceptionFactory for @InTestsMock https://github.com/diffblue/cover-annotations/pull/35
Update version to 1.6.0 https://github.com/diffblue/cover-annotations/pull/36


Changed annotations

@InTestsMock - new attributes throwException and throwExceptionFactory
Supported by Diffblue Cover from 2025.06.02
See https://docs.diffblue.com/features/cover-annotations/mocking-annotations for more details
Full Changelog: https://github.com/diffblue/cover-annotations/compare/%5Bv1.5.0%5D...%5Bv1.6.0%5D