### PR TITLE
Make release wait for publish

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <configuration>
           <publishingServerId>central</publishingServerId>
           <autoPublish>true</autoPublish>
+          <waitUntil>published</waitUntil>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
This prevents the job from instantly finishing as soon as the upload has completed. As if you do not have access to view the maven central portal you will not know if anything failed